### PR TITLE
autoload_files is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Include all stubs in PHPStan configuration file.
 
 ```yaml
 parameters:
-    autoload_files:
+    bootstrapFiles:
         - %rootDir%/../../php-stubs/wordpress-stubs/wordpress-stubs.php
         - %rootDir%/../../php-stubs/woocommerce-stubs/woocommerce-stubs.php
         #- %rootDir%/../../php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php


### PR DESCRIPTION
`autoload_files` has been deprecated since PHPSTAN 0.12.26. Please change the instructions in the README from `autoload_files` to `bootstrapFiles` as instructed in the warning below:

```
> vendor/bin/phpstan analyse -c phpstan.neon
⚠️  You're using a deprecated config option autoload_files. ⚠️️

You might not need it anymore - try removing it from your
configuration file and run PHPStan again.

If the analysis fails, there are now two distinct options
to choose from to replace autoload_files:
1) scanFiles - PHPStan will scan those for classes and functions
   definitions. PHPStan will not execute those files.
2) bootstrapFiles - PHPStan will execute these files to prepare
   the PHP runtime environment for the analysis.

Read more about this in PHPStan's documentation:
https://phpstan.org/user-guide/discovering-symbols

 23/23 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


 [OK] No errors                                  
```