### PR TITLE
Bump the WP stubs requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://github.com/php-stubs/woocommerce-stubs",
     "license": "MIT",
     "require": {
-        "php-stubs/wordpress-stubs": "^5.3 || ^6.0"
+        "php-stubs/wordpress-stubs": "^5.3 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "php": "~7.1 || ~8.0",


### PR DESCRIPTION
Bumped the wp stubs requirment to include WP 7.